### PR TITLE
Cria tela de detalhes do produto

### DIFF
--- a/lib/models/cupons_item_model.dart
+++ b/lib/models/cupons_item_model.dart
@@ -15,10 +15,11 @@ class CuponsItemModel {
     DocumentSnapshot<Map<String, dynamic>> doc,
   ) {
     Map<String, dynamic> data = doc.data()!;
+
     return CuponsItemModel(
       id: doc.id,
       codigo: data['codigo'] as String? ?? 'CÓDIGO INVÁLIDO',
-      porcentagem: (data['porcentagem'] as num? ?? 0).toInt(),
+      porcentagem: data['porcentagem'],
     );
   }
 }

--- a/lib/screens/home/detalhes_produto.dart
+++ b/lib/screens/home/detalhes_produto.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/cupertino.dart';
+
+class DetalhesProduto extends StatelessWidget {
+  const DetalhesProduto({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(child: Text("Detalhe do produto"));
+  }
+}

--- a/lib/screens/home/widgets/cafe_grid_view.dart
+++ b/lib/screens/home/widgets/cafe_grid_view.dart
@@ -15,12 +15,8 @@ class _CafeGridViewState extends State<CafeGridView> {
   @override
   void initState() {
     super.initState();
-    // Carrega os itens do cardápio quando o widget é inicializado,
-    // SE você não fez isso no construtor do MenuProvider.
-    // Usar addPostFrameCallback garante que o contexto esteja disponível.
+
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      // Verifica se já está carregando ou se já tem itens para evitar recargas desnecessárias
-      // ao reconstruir o widget, a menos que seja intencional.
       final menuProvider = Provider.of<MenuProvider>(context, listen: false);
       if (menuProvider.menuItems.isEmpty && !menuProvider.isLoading) {
         menuProvider.carregarItensDoCardapio();


### PR DESCRIPTION
A tela de detalhes do produto foi criada para exibir informações detalhadas sobre um item específico. Além disso, foram feitos ajustes no `CuponsItemModel` para corrigir a leitura da porcentagem e no `CafeGridView` para otimizar o carregamento dos itens do cardápio.